### PR TITLE
Schema update & utilization (closes #12 and #13)

### DIFF
--- a/queuebot/cogs/queue/__init__.py
+++ b/queuebot/cogs/queue/__init__.py
@@ -204,7 +204,7 @@ class BlobQueue(Cog):
         """Moves a suggestion from the council queue to the public queue."""
         logger.info('%s: moving %s to public queue', ctx.author, suggestion)
         reason = reason or None  # do not push empty strings
-        await suggestion.move_to_public_queue(ctx.author.id, reason)
+        await suggestion.move_to_public_queue(who=ctx.author.id, reason=reason)
         await ctx.send(f"Successfully moved #{suggestion.record['idx']}.")
 
     @commands.command()
@@ -213,7 +213,7 @@ class BlobQueue(Cog):
         """Denies an emoji that is currently in the council queue."""
         logger.info('%s: denying %s', ctx.author, suggestion)
         reason = reason or None  # do not push empty strings
-        await suggestion.deny(ctx.author.id, reason)
+        await suggestion.deny(who=ctx.author.id, reason=reason)
         await ctx.send(f"Successfully denied #{suggestion.record['idx']}.")
 
     @commands.command()

--- a/queuebot/cogs/queue/__init__.py
+++ b/queuebot/cogs/queue/__init__.py
@@ -116,17 +116,19 @@ class BlobQueue(Cog):
                 user_id,
                 council_message_id,
                 emoji_id,
-                emoji_name
+                emoji_name,
+                submission_time
             )
             VALUES (
-                $1, $2, $3, $4
+                $1, $2, $3, $4, $5
             )
             RETURNING idx
             """,
             message.author.id,
             msg.id,
             emoji.id,
-            name
+            name,
+            message.created_at
         )
 
         # Log all suggestions to a special channel to keep original files and have history for moderation purposes.
@@ -198,18 +200,20 @@ class BlobQueue(Cog):
 
     @commands.command()
     @is_police()
-    async def approve(self, ctx, suggestion: SuggestionConverter):
+    async def approve(self, ctx, suggestion: SuggestionConverter, *, reason=None):
         """Moves a suggestion from the council queue to the public queue."""
         logger.info('%s: moving %s to public queue', ctx.author, suggestion)
-        await suggestion.move_to_public_queue()
+        reason = reason or None  # do not push empty strings
+        await suggestion.move_to_public_queue(ctx.author.id, reason)
         await ctx.send(f"Successfully moved #{suggestion.record['idx']}.")
 
     @commands.command()
     @is_police()
-    async def deny(self, ctx, suggestion: SuggestionConverter):
+    async def deny(self, ctx, suggestion: SuggestionConverter, *, reason=None):
         """Denies an emoji that is currently in the council queue."""
         logger.info('%s: denying %s', ctx.author, suggestion)
-        await suggestion.deny()
+        reason = reason or None  # do not push empty strings
+        await suggestion.deny(ctx.author.id, reason)
         await ctx.send(f"Successfully denied #{suggestion.record['idx']}.")
 
     @commands.command()

--- a/queuebot/cogs/queue/suggestion.py
+++ b/queuebot/cogs/queue/suggestion.py
@@ -45,11 +45,11 @@ class Suggestion:
 
     @property
     def is_in_public_queue(self):
-        return self.record['public_message_id'] is not None
+        return self.record['council_approved'] is True
 
     @property
     def is_denied(self):
-        return self.record['public_message_id'] is None and self.record['council_message_id'] is None
+        return self.record['council_approved'] is False  # do not accept None
 
     @property
     def emoji_url(self):

--- a/queuebot/cogs/queue/suggestion.py
+++ b/queuebot/cogs/queue/suggestion.py
@@ -58,9 +58,15 @@ class Suggestion:
     @property
     def status(self):
         if self.is_denied:
-            status = 'Denied'
+            if self.record["validation_time"]:
+                status = f'Denied at {self.record["validation_time"]} UTC'
+            else:
+                status = "Denied"
         elif self.is_in_public_queue:
-            status = 'In the public approval queue'
+            if self.record["validation_time"]:
+                status = f'Moved to public queue at {self.record["validation_time"]} UTC'
+            else:
+                status = 'In the public approval queue'
         else:
             status = 'In the private council queue'
 

--- a/queuebot/cogs/queue/suggestion.py
+++ b/queuebot/cogs/queue/suggestion.py
@@ -64,11 +64,19 @@ class Suggestion:
         else:
             status = 'In the private council queue'
 
+        submission_time = self.record["submission_time"] or "Unknown time"
+
+        if self.record["forced_by"]:
+            force_text = f"Forced by: <@{self.record['forced_by']}>\nReason: {self.record['forced_reason']}"
+        else:
+            force_text = ""
+
         return f"""**Suggestion #{self.record['idx']}**
 
-Submitted by <@{self.record['user_id']}>
+Submitted by <@{self.record['user_id']}> at {submission_time}
 Upvotes: **{self.record['upvotes']}** / Downvotes: **{self.record['downvotes']}**
-Status: {status}"""
+Status: {status}
+{force_text}"""
 
     async def process_vote(self, vote_emoji: discord.PartialReactionEmoji, vote_type: VoteType, message_id: int):
         """Processes a vote for this suggestion."""

--- a/queuebot/cogs/queue/suggestion.py
+++ b/queuebot/cogs/queue/suggestion.py
@@ -73,7 +73,7 @@ class Suggestion:
 
         return f"""**Suggestion #{self.record['idx']}**
 
-Submitted by <@{self.record['user_id']}> at {submission_time}
+Submitted by <@{self.record['user_id']}> at {submission_time} UTC
 Upvotes: **{self.record['upvotes']}** / Downvotes: **{self.record['downvotes']}**
 Status: {status}
 {force_text}"""
@@ -121,7 +121,7 @@ Status: {status}
         """, self.record['idx'])
         await self.update_inplace()
 
-    async def move_to_public_queue(self, who=None, reason=None):
+    async def move_to_public_queue(self, *, who=None, reason=None):
         """Moves this suggestion to the public queue."""
         if self.is_in_public_queue:
             raise self.OperationError(
@@ -179,7 +179,7 @@ Status: {status}
             except discord.HTTPException:
                 await self.bot.log(f'\N{WARNING SIGN} Failed to DM `{name_id(user)}` about their approved emoji.')
 
-    async def deny(self, who=None, reason=None):
+    async def deny(self, *, who=None, reason=None):
         """Denies this emoji."""
         # Sane checks for command usage.
         if self.is_in_public_queue:

--- a/queuebot/cogs/queue/suggestion.py
+++ b/queuebot/cogs/queue/suggestion.py
@@ -209,6 +209,8 @@ Status: {status}
             """,
             reason, who, datetime.datetime.utcnow(), self.record['idx'])
 
+        await self.update_inplace()
+
         changelog = self.bot.get_channel(config.council_changelog)
 
         await changelog.send(f'<:{config.deny_emoji}> denied: {emoji} (by <@{user_id}>)')

--- a/schema.sql
+++ b/schema.sql
@@ -1,3 +1,17 @@
+
+-- migration compat, remove when suitable time has passed
+ALTER TABLE IF EXISTS suggestions
+    -- timestamps
+    ADD COLUMN IF NOT EXISTS submission_time TIMESTAMP, -- when this was submitted
+    ADD COLUMN IF NOT EXISTS validation_time TIMESTAMP, -- when this was approved or denied
+
+    -- validation
+    ADD COLUMN IF NOT EXISTS council_approved BOOLEAN, -- was the emoji approved by Council?
+    ADD COLUMN IF NOT EXISTS forced_reason TEXT, -- reason for Council validation being forced.
+    ADD COLUMN IF NOT EXISTS forced_by BIGINT -- ID of the user who forced this. if not forced, this is NULL.
+;
+
+
 CREATE TABLE IF NOT EXISTS suggestions (
     -- suggestion id
     idx SERIAL PRIMARY KEY,
@@ -17,5 +31,14 @@ CREATE TABLE IF NOT EXISTS suggestions (
 
     -- votes
     upvotes INT DEFAULT 0,
-    downvotes INT DEFAULT 0
+    downvotes INT DEFAULT 0,
+
+    -- timestamps
+    submission_time TIMESTAMP, -- when this was submitted
+    validation_time TIMESTAMP, -- when this was approved or denied
+
+    -- validation
+    council_approved BOOLEAN, -- was the emoji approved by Council?
+    forced_reason TEXT, -- reason for Council validation being forced.
+    forced_by BIGINT -- ID of the user who forced this. if not forced, this is NULL.
 );


### PR DESCRIPTION
**This requires a migration!** To perform it, do `psql -d mydb -U myuser < schema.sql` as in the README and the database will be brought up to speed.

This adds timestamps for submission and validation(approval/denial), as well as adding columns related to forced validations, closing #12 and #13.