### PR TITLE
leave suggestions in the suggestions channel (#10)

### DIFF
--- a/queuebot/cogs/queue/__init__.py
+++ b/queuebot/cogs/queue/__init__.py
@@ -118,10 +118,11 @@ class BlobQueue(Cog):
                 council_message_id,
                 emoji_id,
                 emoji_name,
-                submission_time
+                submission_time,
+                suggestions_message_id
             )
             VALUES (
-                $1, $2, $3, $4, $5
+                $1, $2, $3, $4, $5, $6
             )
             RETURNING idx
             """,
@@ -129,7 +130,8 @@ class BlobQueue(Cog):
             msg.id,
             emoji.id,
             name,
-            message.created_at
+            message.created_at,
+            message.id
         )
 
         # Log all suggestions to a special channel to keep original files and have history for moderation purposes.
@@ -141,7 +143,7 @@ class BlobQueue(Cog):
             file=discord.File(buffer, filename=attachment.filename)
         )
 
-        await message.delete()
+        await message.add_reaction('\N{EYES}')
         await respond(SUGGESTION_RECIEVED)
 
     async def on_raw_reaction_add(self, emoji: discord.PartialReactionEmoji, message_id: int,

--- a/queuebot/utils/messages.py
+++ b/queuebot/utils/messages.py
@@ -34,7 +34,8 @@ BAD_SUGGESTION_MSG = (
 SUGGESTION_RECIEVED = (
     'Thanks for your emoji submission to the '
     'Google Blob Server! It\'s been added to our internal vote queue, '
-    'so expect an update soon!'
+    'so expect an update soon! Your suggestion was left in the channel as a '
+    'public indication, please don\'t delete it!'
 )
 
 SUGGESTION_APPROVED = (

--- a/schema.sql
+++ b/schema.sql
@@ -1,4 +1,3 @@
-
 -- migration compat, remove when suitable time has passed
 ALTER TABLE IF EXISTS suggestions
     -- timestamps
@@ -8,7 +7,10 @@ ALTER TABLE IF EXISTS suggestions
     -- validation
     ADD COLUMN IF NOT EXISTS council_approved BOOLEAN, -- was the emoji approved by Council?
     ADD COLUMN IF NOT EXISTS forced_reason TEXT, -- reason for Council validation being forced.
-    ADD COLUMN IF NOT EXISTS forced_by BIGINT -- ID of the user who forced this. if not forced, this is NULL.
+    ADD COLUMN IF NOT EXISTS forced_by BIGINT, -- ID of the user who forced this. if not forced, this is NULL.
+
+    -- message ids
+    ADD COLUMN IF NOT EXISTS suggestions_message_id BIGINT -- ID of the message ID in the suggestions queue
 ;
 
 

--- a/schema.sql
+++ b/schema.sql
@@ -27,6 +27,9 @@ CREATE TABLE IF NOT EXISTS suggestions (
     -- message id in the #approval-queue
     public_message_id BIGINT,
 
+    -- message id in the #suggestions
+    suggestions_message_id BIGINT,
+
     -- emoji data
     emoji_id BIGINT,
     emoji_name TEXT,


### PR DESCRIPTION
Instead of instantly deleting messages upon processing a new submission,
we add a reaction to it instead, and leave it in the channel. Once the
emoji gets denied or approved and moved to the public approval queue,
the message in the public suggestions channel gets deleted.

This has the advantage of letting the public know what blobs are
currently being processed.

A new column in the database schema had to be added in order to track
the message ID of the suggestion in the suggestions channel.

If the bot fails to delete the message or fails to find it at all, it
logs it in the bot log for staff to diagnose.

The "successful suggestion" message was amended with a tiny notice
encouraging blob artists to not delete their message in the suggestions
channel.

---

~~I'm pretty sure GitHub will automatically close #10 if this gets merged.~~ Yep, it will.

I have tested it with Devon's new schema and it seems to work fine with forced denials and approvals.