### PR TITLE
Move some hardcoded stuff to the config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -168,6 +168,12 @@ Its basic structure is as follows:
 
   suggestions_log = 1234567890  # ID of the suggestions log channel
   council_changelog = 1234567890  # ID of the council changelog channel
+  
+  def should_approve(upvotes, downvotes): # Allow for a custom formula
+      return upvotes >= 10 and upvotes - downvotes >= 5 and upvotes + downvotes >= 15
+
+  def should_decline(upvotes, downvotes): # Allow for a custom formula
+      return downvotes >= 10 and downvotes - upvotes >= 5 and upvotes + downvotes >= 15
 
 Substitute values here for your own.
 

--- a/README.rst
+++ b/README.rst
@@ -131,49 +131,7 @@ config.py
 
 A ``config.py`` file should be placed in the project root, alongside ``run.py``.
 
-Its basic structure is as follows:
-
-.. code-block:: python
-
-  token = "mytoken"
-
-  pg_credentials = {
-    "host": "localhost",
-    "port": 5432,
-    "user": "myuser",
-    "database": "mydb",
-    "password": "mypassword",
-    "timeout": 60
-  }
-
-  bot_log = 1234567890  # replace this with the ID of your bot logging channel
-  
-  admins = [1234567890, 9876543210]  # add IDs of anyone who needs admin perms on this bot
-
-  authority_roles = [1234567890, 9876543210]  # IDs of roles that have authority over this bot (Blob Police, etc)
-
-  council_roles = [1234567890, 9876543210]  # IDs of roles considered Council (Blob Council, Blob Council Lite, etc)
-
-  blob_guilds = [37428175841, ]  # IDs of all guilds the bot updates an emoji list in
-
-  approve_emoji_id = 1234567890  # ID of the approval emoji
-  deny_emoji_id = 1234567890  # ID of the denial emoji
-
-  approve_emoji = "name:1234567890"  # representation of the approval emoji
-  deny_emoji = "name:1234567890"  # representation of the denial emoji
-
-  suggestions_channel = 1234567890  # ID of the suggestions channel
-  council_queue = 1234567890  # ID of the council queue channel
-  approval_queue = 1234567890  # ID of the approval queue channel
-
-  suggestions_log = 1234567890  # ID of the suggestions log channel
-  council_changelog = 1234567890  # ID of the council changelog channel
-  
-  def should_approve(upvotes, downvotes): # Allow for a custom formula
-      return upvotes >= 10 and upvotes - downvotes >= 5 and upvotes + downvotes >= 15
-
-  def should_decline(upvotes, downvotes): # Allow for a custom formula
-      return downvotes >= 10 and downvotes - upvotes >= 5 and upvotes + downvotes >= 15
+The example config is at ``config.example.py``.
 
 Substitute values here for your own.
 

--- a/config.example.py
+++ b/config.example.py
@@ -1,0 +1,36 @@
+token = "mytoken"
+
+pg_credentials = {
+  "host": "localhost",
+  "port": 5432,
+  "user": "myuser",
+  "database": "mydb",
+  "password": "mypassword",
+  "timeout": 60
+}
+
+bot_log = 1234567890  # replace this with the ID of your bot logging channel
+ 
+admins = [1234567890, 9876543210]  # add IDs of anyone who needs admin perms on this bot
+
+authority_roles = [1234567890, 9876543210]  # IDs of roles that have authority over this bot (Blob Police, etc)
+
+council_roles = [1234567890, 9876543210]  # IDs of roles considered Council (Blob Council, Blob Council Lite, etc)
+
+blob_guilds = [37428175841, ]  # IDs of all guilds the bot updates an emoji list in
+
+approve_emoji_id = 1234567890  # ID of the approval emoji
+deny_emoji_id = 1234567890  # ID of the denial emoji
+
+approve_emoji = "name:1234567890"  # representation of the approval emoji
+deny_emoji = "name:1234567890"  # representation of the denial emoji
+
+suggestions_channel = 1234567890  # ID of the suggestions channel
+council_queue = 1234567890  # ID of the council queue channel
+approval_queue = 1234567890  # ID of the approval queue channel
+
+suggestions_log = 1234567890  # ID of the suggestions log channel
+council_changelog = 1234567890  # ID of the council changelog channel
+  
+required_difference = 15 # The difference between upvotes and downvotes required to approve/deny automatically
+required_votes = 15 # The amount of votes needed to process the votes

--- a/queuebot/cogs/queue/suggestion.py
+++ b/queuebot/cogs/queue/suggestion.py
@@ -304,7 +304,7 @@ Status: {status}
         """
         upvotes = self.record['upvotes']
         downvotes = self.record['downvotes']
-        if upvotes + downvotes <= required_votes:
+        if upvotes + downvotes < required_votes:
             # It doesn't hit the required votes, lets just exit out of the function, right?
             return
         if upvotes - downvotes >= required_difference:

--- a/queuebot/cogs/queue/suggestion.py
+++ b/queuebot/cogs/queue/suggestion.py
@@ -9,7 +9,7 @@ import discord
 import config
 from queuebot.utils import SUBMITTER_NOT_FOUND, UPLOADED_EMOJI_NOT_FOUND, SUGGESTION_APPROVED, SUGGESTION_DENIED, \
     name_id
-from config import suggestions_channel
+from config import suggestions_channel, should_approve, should_decline
 
 log = logging.getLogger(__name__)
 
@@ -303,7 +303,7 @@ Status: {status}
         downvotes = self.record['downvotes']
 
         # This logic is copied from b1nb0t.
-        if upvotes >= 10 and upvotes - downvotes >= 5 and upvotes + downvotes >= 15:
+        if should_approve(upvotes, downvotes): # Allow for custom formula in config
             # Since we don't track internal queue/public queue votes separately, we'll have to reset the upvotes
             # and downvotes columns.
             await self.db.execute(
@@ -312,7 +312,7 @@ Status: {status}
             await self.update_inplace()
 
             await self.move_to_public_queue()
-        elif downvotes >= 10 and downvotes - upvotes >= 5 and upvotes + downvotes >= 15:
+        elif should_decline(upvotes, downvotes): # Allow for custom formula in config
             await self.deny()
 
     async def delete_from_suggestions_channel(self):


### PR DESCRIPTION
This allows you to set a custom formula for accepting/declining emotes, this is mostly for smaller servers who decide to self-host the bot, they can use the bot with a smaller team.